### PR TITLE
Revert "Set comment repo name as CanCLID/jyutping.org-comment (#23)"

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -161,7 +161,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY
         desc = "粵典"
 
 [params.utterances]
-	repo = "CanCLID/jyutping.org-comment"
+	repo = "eatradish/jyutping.org"
 	
 # [[params.links.user]]
 # 	name = "Stack Overflow"


### PR DESCRIPTION
This reverts commit 12c153c6738cad6b280c8e09bfe1325a36c2177f. because Google Ads banned utterances