### PR TITLE
Update _index.md

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -9,5 +9,5 @@ hide_feedback: true
 ---
 
 {{< alert title="Goal">}}
-Mastering pinyin is the prevailing practice of Chinese readers; to that end, so too can Jyutping be mastered, after reading “The Linguistic Society of Hong Kong Cantonese Romanization Scheme”.
+Mastering pinyin is the prevailing practice of Chinese readers; to that end, so too can Jyutping be mastered, after understanding “The Linguistic Society of Hong Kong Cantonese Romanization Scheme”.
 {{< /alert >}}


### PR DESCRIPTION
switched out "reading" to "understanding" [The Linguistic Society of Hong Kong Cantonese Romanization Scheme], because while "reading" is more of the literal translation, the actual intent of the sentence is really being able to master jyutping, but since "master(ing)" is used several times already and it's preferable to focus on mastering jyutping via understanding how it works (in terms of understanding how using jyutping allows the learner to more accurately enunciate cantonese)