### PR TITLE
fix: catalogue for default locale

### DIFF
--- a/src/components/BlogCatalogue.astro
+++ b/src/components/BlogCatalogue.astro
@@ -1,5 +1,6 @@
 ---
 // src/components/BlogCatalogue.astro
+import { I18n } from "@/i18n/utils";
 import type { CollectionEntry } from "astro:content";
 
 // Get current locale from Astro's global
@@ -37,9 +38,14 @@ const { posts, currentSlug } = Astro.props;
         const postSlug = post.slug.includes("/")
           ? post.slug.substring(post.slug.indexOf("/") + 1)
           : post.slug;
-        const localePrefix = post.slug.includes("/")
+
+        let localePrefix = post.slug.includes("/")
           ? `/${post.slug.split("/")[0]}`
           : "";
+        if (I18n.defaultLocale === localePrefix.replace(/\//g, "")) {
+          // defaultLocale is not included in getStaticPaths
+          localePrefix = "";
+        }
         const postLink = `${localePrefix}/blog/${postSlug}/`;
         const isActive =
           postSlug === currentSlug &&


### PR DESCRIPTION
Fix catalogue for default locale. The default locale [is excluded in getStaticPaths](https://github.com/CanCLID/jyutping.org/blob/ce66607bbe30da1771fb6fce3da412cba43f9817/src/pages/%5Blocale%5D/index.astro#L17). Which will make path with defaultLocale 404